### PR TITLE
dark mode

### DIFF
--- a/css/landing_page.css
+++ b/css/landing_page.css
@@ -69,6 +69,115 @@
 	--z-modal: 1000;
 }
 
+@media(prefers-color-scheme: dark) {
+	:root {
+		--color-primary: #0066ff;
+		--color-primary-dark: #0052cc;
+		--color-primary-ligt: #4d94ff;
+		--color-secondary: #ff3366;
+		--color-secondary-dark: #e6004c;
+		--color-secondary-light: #ff6699;
+		--color-dark: #ffffff;
+		--color-dark-blue: #1c2541;
+		--color-dark-blue2: #212c4e;
+		--color-white: #0a1128;
+		--color-light: #f8f9fa;
+		--color-gray: #6c757d;
+		--color-gray-light: #dee2e6;
+		--shadow-sm: 0 2px 4px var(--color-dark-blue);
+		--shadow-md: 0 4px 8px var(--color-dark-blue);
+		--shadow-lg: 0 10px 30px var(--color-dark-blue);
+		--shadow-xl: 0 20px 50px var(--color-dark-blue);
+	}
+	.stat-card{
+		background: var(--color-dark-blue) !important;
+	}
+	.stat-card-label{
+		color: var(--color-dark) !important;
+	}
+	.hero-description {
+		color: var(--color-dark) !important;
+	}
+	.how-it-works {
+		background: var(--color-dark-blue) !important;
+	}
+	.feature-card {
+		background: var(--color-dark-blue) !important;
+	}
+	.footer {
+		background: var(--color-dark-blue) !important;
+		color: var(--color-dark) !important;
+	}
+	.footer-brand .logo {
+		color: var(--color-dark) !important;
+	}
+	.footer-column .footer-title {
+		color: var(--color-dark) !important;
+	}
+	.social-link {
+		background: rgba(0, 0, 0, 0.1) !important;
+	}
+	.social-link:hover {
+		background: var(--color-primary) !important;
+	}
+	.github:hover{
+		background: rgba(0, 0, 0, 0.1) !important;
+	}
+	.step-description {
+		color: var(--color-gray-light) !important;
+	}
+	.feature-description {
+		color: var(--color-gray-light) !important;
+	}
+	.cta-title {
+		color: var(--color-dark) !important;
+	}
+	.cta-description {
+		color: var(--color-gray-light) !important;
+	}
+	.cta-note {
+		color: var(--color-gray-light) !important;
+	}
+	.header{
+		background: var(--dark-blue2) !important;
+	}
+	.btn-primary{
+		color: var(--color-dark) !important;
+	}
+	.btn-large{
+		color: var(--color-dark) !important;
+	}
+	.btn-outline{
+		border-color: var(--color-gray) !important;
+	}
+	.page-header{
+		background: var(--color-dark-blue) !important;
+		color: var(--color-dark) !important;
+	}
+	.team-card{
+		background: var(--color-dark-blue) !important;
+		box-shadow: var(--shadow-lg) !important;
+	}
+	.value-card{
+		background: var(--color-dark-blue) !important;
+	}
+	.auth-form{
+		border-color: var(--color-gray) !important;	
+	}
+	.legal-toc{
+		background: var(--color-dark-blue) !important;
+	}
+	.cookie-type{
+		background: var(--color-dark-blue) !important;
+	}
+	.browser-instructions{
+		background: var(--color-dark-blue) !important;
+	}
+	.third-party-list{
+		background: var(--color-dark-blue) !important;
+	}
+}
+
 /* reset */
 * {
 	margin: 0;


### PR DESCRIPTION
---
name: Pull Request
about: Proponer cambios en el código o nuevas funcionalidades
title: '[PR] Añadido modo oscuro automático con CSS'
labels: 'enhancement'
assignees: ''
---

# Descripción
Se ha añadido soporte para **modo oscuro automático** utilizando únicamente CSS, basado en la preferencia del sistema (`prefers-color-scheme`). Esto permite que la interfaz cambie automáticamente entre modo claro y oscuro según la configuración del usuario, mejorando la experiencia visual y la accesibilidad.

---

# Tipo de cambio
Marque con una "X" las opciones relevantes:
- [ ] Bugfix
- [x] Nueva característica
- [ ] Mejora
- [ ] Refactorización
- [ ] Cambio en la documentación
- [ ] Otros: _describa_

---

# Cómo probar los cambios
1. Asegúrate de que tu sistema operativo tenga configurado el modo oscuro o claro.
2. Abre la aplicación en el navegador.
3. Cambia la preferencia del sistema (por ejemplo, en Windows, macOS o Android).
4. Verifica que el diseño se adapte automáticamente al modo correspondiente.

---

# ¿Se ha realizado alguna prueba?
- [x] Sí
- [ ] No

Se realizaron pruebas manuales cambiando la preferencia del sistema entre modo claro y oscuro en distintos navegadores (Chrome, Firefox) y sistemas operativos. El comportamiento fue el esperado.

---

# Impacto en el código
- Se modificaron archivos CSS para incluir reglas bajo `@media (prefers-color-scheme: dark)`.
- No se ha afectado ninguna funcionalidad existente. Este cambio es progresivo y no rompe compatibilidad con navegadores que no soportan `prefers-color-scheme`.

---

# Notas adicionales
Este es un primer paso para ofrecer una mejor experiencia adaptativa. En el futuro, se podría permitir a los usuarios elegir manualmente entre los modos claro/oscuro, independientemente de su sistema operativo.
